### PR TITLE
Use Android Support Repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ gradle.properties
 target
 
 libs-generated
+libs-assembled
+libs-expanded
 linen-pickle/build
 wheat-ancient/build
 

--- a/linen-glue/build.gradle
+++ b/linen-glue/build.gradle
@@ -6,8 +6,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':wheat-ancient')
-    compile 'com.android.support:recyclerview-v7:23.4.0'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:design:23.4.0'
-    compile "com.android.support:cardview-v7:23.4.0"
 }
+
+apply from: '../targets.gradle'
+
+linenDependencies.loadSupportLibrary()

--- a/linen-links.rb
+++ b/linen-links.rb
@@ -30,6 +30,7 @@ def create_flow_factory dir_flow
 end
 
 targets = [
+  "android-jars",
   "wheat-build",
   "wheat-modern",
   "wheat-macros",
@@ -45,6 +46,8 @@ targets = [
   "linen-links.rb",
   "project",
   "local.properties",
+  "targets.gradle",
+  "build.gradle",
   "README.md",
 ]
 

--- a/linen-modern/src/main/scala/x7c1/linen/modern/init/unread/DrawerMenuInitializer.scala
+++ b/linen-modern/src/main/scala/x7c1/linen/modern/init/unread/DrawerMenuInitializer.scala
@@ -119,7 +119,7 @@ class UnreadChannelsMenu(
       }
     }
   }
-  override def viewHolderProviders = Seq(viewHolderProvider)
+  override def viewHolderProviders[B >: MenuRowLabel] = Seq(viewHolderProvider)
 }
 
 class OnMenuItemClick(

--- a/linen-starter/build.gradle
+++ b/linen-starter/build.gradle
@@ -34,9 +34,8 @@ dependencies {
     compile fileTree(dir: 'libs-generated', include: ['*.jar'])
     compile project(':linen-pickle')
     compile project(':linen-glue')
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
-    compile 'com.android.support:design:23.4.0'
-    compile 'com.android.support:cardview-v7:23.4.0'
+}
+
+dependencies {
     compile 'com.android.support:multidex:1.0.1'
 }

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -4,3 +4,5 @@ resolvers += Resolver.url(
   url("http://dl.bintray.com/x7c1/android"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("x7c1" % "wheat-harvest" % "0.1.0")
+
+addSbtPlugin("x7c1" % "wheat-splicer-assembly" % "0.1.0")

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,2 +1,6 @@
 
-addSbtPlugin("x7c1" %% "wheat-harvest" % "0.1-SNAPSHOT")
+resolvers += Resolver.url(
+  "bintray-x7c1-android",
+  url("http://dl.bintray.com/x7c1/android"))(Resolver.ivyStylePatterns)
+
+addSbtPlugin("x7c1" % "wheat-harvest" % "0.1.0")

--- a/targets.gradle
+++ b/targets.gradle
@@ -1,0 +1,10 @@
+ext.linenDependencies = [
+        loadSupportLibrary: {
+            dependencies {
+                compile 'com.android.support:recyclerview-v7:23.4.0'
+                compile 'com.android.support:appcompat-v7:23.4.0'
+                compile 'com.android.support:design:23.4.0'
+                compile 'com.android.support:cardview-v7:23.4.0'
+            }
+        }
+]

--- a/wheat-ancient/src/main/scala/x7c1/wheat/modern/menu/MenuItem.scala
+++ b/wheat-ancient/src/main/scala/x7c1/wheat/modern/menu/MenuItem.scala
@@ -8,7 +8,7 @@ import scala.annotation.tailrec
 trait MenuItem[+A] {
   def length: Int
   def findItemAt(position: Int): Option[SingleMenuItem[A]]
-  def viewHolderProviders: Seq[ViewHolderProvider[_ <: A]]
+  def viewHolderProviders[B >: A]: Seq[ViewHolderProvider[_ <: B]]
 }
 
 trait MenuText {
@@ -22,7 +22,7 @@ class SingleMenuItem[+A](
 
   override def findItemAt(position: Int) = Some(this)
 
-  override def viewHolderProviders: Seq[ViewHolderProvider[_ <: A]] = Seq(provider)
+  override def viewHolderProviders[B >: A]: Seq[ViewHolderProvider[_ <: B]] = Seq(provider)
 
   def viewType: Int = provider.layoutId()
 }
@@ -50,7 +50,7 @@ class MenuItems[A] private (items: MenuItem[A]*) extends MenuItem[A] {
       item.findItemAt(position - prev)
     }
   }
-  override def viewHolderProviders = {
+  override def viewHolderProviders[B >: A] = {
     items.flatMap(_.viewHolderProviders)
   }
   def inflate(parent: ViewGroup, viewType: Int): A = {


### PR DESCRIPTION
Now that Android Support Library is declared as obsolete, jar files are not downloaded by default from SDK Manager. This PR enables each project to load local aar files retrieved from Android Support Repository, instead of jar files in old style.